### PR TITLE
Allow to download without unpacking

### DIFF
--- a/in/main.go
+++ b/in/main.go
@@ -42,10 +42,16 @@ func main() {
 		sourceURL.User = nil
 	}
 
+	var command string
+	if request.Source.OnlyDownload {
+		command = "cd \"$2\" && curl -k -O -H \"$3\" \"$1\""
+	} else {
+		command = "curl -k -H \"$3\" \"$1\" | gunzip | tar -C \"$2\" -xf -"
+	}
 	curlPipe := exec.Command(
 		"sh",
 		"-c",
-		"curl -k -H \"$3\" \"$1\" | gunzip | tar -C \"$2\" -xf -",
+		command,
 		"sh", sourceURL.String(), destination, authHeader,
 	)
 

--- a/models/models.go
+++ b/models/models.go
@@ -5,7 +5,8 @@ type InRequest struct {
 }
 
 type Source struct {
-	URI string `json:"uri"`
+	URI          string `json:"uri"`
+	OnlyDownload bool   `json:"only_download"`
 }
 
 type InResponse struct{}


### PR DESCRIPTION
With 

```
{"source": {"only_download": true, "uri": "https://d26ekeud912fhb.cloudfront.net/bosh-stemcell/aws/light-bosh-stemcell-2969-aws-xen-hvm-ubuntu-trusty-go_agent.tgz"}}
```

The file would be downloaded into 
destination/light-bosh-stemcell-2969-aws-xen-hvm-ubuntu-trusty-go_agent.tgz
