### PR TITLE
Allow archive resource to follow redirects

### DIFF
--- a/in/main.go
+++ b/in/main.go
@@ -45,7 +45,7 @@ func main() {
 	curlPipe := exec.Command(
 		"sh",
 		"-c",
-		"curl -k -H \"$3\" \"$1\" | gunzip | tar -C \"$2\" -xf -",
+		"curl --location-trusted -k -H \"$3\" \"$1\" | gunzip | tar -C \"$2\" -xf -",
 		"sh", sourceURL.String(), destination, authHeader,
 	)
 


### PR DESCRIPTION
Otherwise it will fail to follow URIs like: 

https://cli.run.pivotal.io/stable?release=linux64-binary&source=github

Jim && Corey
