### PR TITLE
Add  --location-trusted -k to curl in out/

### DIFF
--- a/out/main.go
+++ b/out/main.go
@@ -37,7 +37,7 @@ func main() {
 	curlPipe := exec.Command(
 		"sh",
 		"-c",
-		`tar --owner=0 --group=0 -C "$1" -czf - . | curl -H "$3" -X PUT "$2" -T -`,
+		`tar --owner=0 --group=0 -C "$1" -czf - . | curl --location-trusted -k -H "$3" -X PUT "$2" -T -`,
 		"sh",
 		filepath.Join(sourceDirectory, directory),
 		sourceURL.String(),


### PR DESCRIPTION
This matches the curl call used during in/
Needed when ATC presents untrusted certs